### PR TITLE
Remove margin:auto from cinnamon menu applet and default theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arc Theme
 
-Arc is a flat theme with transparent elements for GTK 3, GTK 2 and GNOME Shell which supports GTK 3 and GTK 2 based desktop environments like GNOME, Unity, Budgie, Pantheon, Xfce, MATE, etc.
+Arc is a flat theme with transparent elements for GTK 3, GTK 2 and GNOME Shell which supports GTK 3 and GTK 2 based desktop environments like GNOME, Unity, Budgie, Pantheon, Xfce, MATE, Cinnamon (>=3.4) etc.
 
 ## Arc is available in three variants 
 

--- a/common/cinnamon/cinnamon-dark.css
+++ b/common/cinnamon/cinnamon-dark.css
@@ -964,7 +964,6 @@ StScrollBar {
   -boxpointer-gap: 5px; }
 
 .menu-favorites-box {
-  margin: auto;
   padding: 10px;
   transition-duration: 300;
   background-color: #383C4A;
@@ -975,7 +974,6 @@ StScrollBar {
   border: 1px solid transparent; }
 
 .menu-places-box {
-  margin: auto;
   padding: 10px;
   border: 0px solid red; }
 

--- a/common/cinnamon/cinnamon.css
+++ b/common/cinnamon/cinnamon.css
@@ -964,7 +964,6 @@ StScrollBar {
   -boxpointer-gap: 5px; }
 
 .menu-favorites-box {
-  margin: auto;
   padding: 10px;
   transition-duration: 300;
   background-color: #F5F6F7;
@@ -975,7 +974,6 @@ StScrollBar {
   border: 1px solid transparent; }
 
 .menu-places-box {
-  margin: auto;
   padding: 10px;
   border: 0px solid red; }
 

--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -1099,7 +1099,6 @@ StScrollBar {
 //
 .menu {
   &-favorites-box {
-    margin: auto;
     padding: 10px;
     transition-duration: 300;
     background-color: $bg_color;
@@ -1116,7 +1115,6 @@ StScrollBar {
   &-places {
 
     &-box {
-      margin: auto;
       padding: 10px;
       border: 0px solid red;
     }


### PR DESCRIPTION
Upstream PR #788 - This avoids warning messages as margin:auto
is not supported in cinnamon 3.4 and later

![workspace 1_727](https://user-images.githubusercontent.com/996240/32989454-3424cd60-cd0e-11e7-9c03-2e9679fe8fd6.png)

favourites section as per picture same before and after.

Tested cinnamon 3.4.6 ubuntu 17.10

unlike GNOME there isn't any versioning restrictions for cinnamon - so README updated instead.