### PR TITLE
Mate screensaver styling

### DIFF
--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -829,6 +829,38 @@ panel-toplevel.background {
 .panel .menu .spinner,
 .menu .spinner { opacity: 1 } // Fixes sound indicator buttons
 
+/********************
+ * Mate-Screensaver *
+ ********************/
+
+.lock-dialog {
+    background-color: $panel_bg;
+    color: white;
+
+    & entry, entry:focus textview text {
+        background-color: transparent;
+        color: white;
+        border-style: none;
+        border-bottom: 1px solid $borders_color;
+        border-radius: 1px;
+    }
+
+    frame > border {
+            border-style: none;
+            border-width: 0px;
+        }
+
+    & notebook {
+        color: white;
+        background-color: gtkopacity($panel_bg, 0.8);
+    }
+
+    & button {
+        @extend %selected-button;
+    }
+}
+
+
 //
 // Wingpanel Popover
 //


### PR DESCRIPTION
I've based this on 2018_01_release ... I presume this will be merged to master on release?

Mate screensaver styling before (i.e. not themed)

![ubuntu budgie - new development artful running - oracle vm virtualbox_028](https://user-images.githubusercontent.com/996240/34742946-efa0a962-f57f-11e7-8684-8890203d409b.png)

after the patch it is now arc-styled

![ubuntu budgie - new development artful running - oracle vm virtualbox_029](https://user-images.githubusercontent.com/996240/34742966-ff71fbde-f57f-11e7-982b-c65a8716e0fb.png)
