### PR TITLE
fix color top bar gnome in gnome-shell

### DIFF
--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -960,7 +960,7 @@ StScrollBar {
       & > .system-status-icon { icon-shadow: none; }
     }
 
-    .system-status-icon { icon-size: 16px; padding: 0 4px; }
+    .system-status-icon { color: $selected_fg_color; icon-size: 16px; padding: 0 4px; }
     .unlock-screen &,
     .login-screen &,
     .lock-screen & {
@@ -969,11 +969,16 @@ StScrollBar {
     }
   }
 
+  .panel-button > *{
+    color: $selected_fg_color;
+  }
+
     #panelActivities.panel-button { -natural-hpadding: 12px; }
 
   .panel-status-indicators-box,
   .panel-status-menu-box {
     spacing: 2px;
+    color: $selected_fg_color;
   }
 
   // spacing between power icon and (optional) percentage label


### PR DESCRIPTION
I fixed the problem #46 now the text in the top bar of gnome is white

![screenshot from 2018-01-23 13-45-28](https://user-images.githubusercontent.com/18738278/35276439-b64044f6-0043-11e8-9060-ee4d93c83ec9.png)
