### PR TITLE
fix bouncing launcher icons in cinnamon (again)

### DIFF
--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -1512,11 +1512,13 @@ StScrollBar {
   }
 
   .panel-bottom & {
+    margin-top: 0;
     margin-bottom: 0;
   }
 
   .panel-top & {
     margin-top: 0;
+    margin-bottom: 0;
     padding-top: 0;
   }
 


### PR DESCRIPTION
I've only tested this by editing the css files directly but I'm 99% sure I got this right in this pull request. Please test before merging...