### PR TITLE
Add a workaround for Chrome(ium) CSD-mode titlebuttons (#62)

### DIFF
--- a/common/gtk-3.0/3.18/sass/_applications.scss
+++ b/common/gtk-3.0/3.18/sass/_applications.scss
@@ -805,3 +805,15 @@ SwitchboardCategoryView .view:selected,
 SwitchboardCategoryView .view:selected:focus {
   color: $fg_color;
 }
+
+//
+// Chromium
+//
+GtkWindow.background.chromium {
+  // See details in nav_button_provider_gtk3.cc
+  .header-bar.titlebar .button.titlebutton {
+    // move button spacing from padding to margin
+    margin: 0px ((24px - 16px) / 2);
+    padding: 0px;
+  }
+}

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -903,3 +903,17 @@ panel-toplevel.background {
 //SwitchboardCategoryView .view:selected:focus {
 //  color: $fg_color;
 //}
+
+//
+// Chromium
+//
+window.background.chromium {
+  // See details in nav_button_provider_gtk3.cc
+  headerbar.titlebar button.titlebutton {
+    min-width: 16px;
+    min-height: 16px;
+    // move button spacing from padding to margin
+    margin: 0px ((24px - 16px) / 2);
+    padding: 0px;
+  }
+}


### PR DESCRIPTION
See details in nav_button_provider_gtk3.cc of Chromium source.
Those titlebutton sizes should be equal to Gtk.IconSize.MENU if
Gtk+ themes provided the customed titlebutton icon images.

 * Set min-width/height as 16px without any padding.
 * Move CSD-titlebutton horizontal spacing from padding to outer margins.

This should fix the issue: #62