### PR TITLE
Add missing 1px hidden border for finer .show-apps-icon alignment

### DIFF
--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -1699,9 +1699,10 @@ StScrollBar {
     height: 4px;
   }
 
-  // Add missing 1px hidden border for finer .show-apps-icon alignment
-  // like %icon_tile
-  .show-apps .overview-icon { border: 1px solid transparent; }
+  // Add missing 1px margin for finer .show-apps-icon alignment
+  // via margin property instead to keep 1px smaller .show-apps-icon size
+  // like standard #dash styling. Better than 1px transparent border.
+  .show-apps .overview-icon { margin: 1px; }
 
   @each $var in 1, 2, 3, 4 {
     .running#{$var} .app-well-app-running-dot {

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -1699,6 +1699,10 @@ StScrollBar {
     height: 4px;
   }
 
+  // Add missing 1px hidden border for finer .show-apps-icon alignment
+  // like %icon_tile
+  .show-apps .overview-icon { border: 1px solid transparent; }
+
   @each $var in 1, 2, 3, 4 {
     .running#{$var} .app-well-app-running-dot {
       background-image: url("common-assets/dash/running#{$var}.svg");


### PR DESCRIPTION
.overview-icon class contained in .app-well-app has the 1px hidden border
via %icon_tile, but .overview-icon contained in ".show-apps" did not.
I think that might cause some unwanted .show-apps-icon shifting
(mis-alignment). So I added that border in case .show-apps class was
contained by #dashtodockContainer.

This should fix the issue #33.