### PR TITLE
remove black dot under app-menu-icon #824

### DIFF
--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -932,6 +932,7 @@ StScrollBar {
     -minimum-hpadding: 6px;
     font-weight: bold;
     color: $_panel_fg_color;
+    text-shadow: none;
     transition-duration: 100ms;
     border-bottom-width: 1px;
     border-color: transparent;
@@ -943,11 +944,23 @@ StScrollBar {
       margin-right: 0px;
     }
 
+    .system-status-icon,
+    .app-menu-icon > StIcon,
+    .popup-menu-arrow {
+      icon-shadow: none;
+    }
+
     &:hover {
       color: $_panel_fg_color;
       background-color: transparentize(black, 0.83);
       border-bottom-width: 1px;
       border-color: transparent;
+
+      .system-status-icon,
+      .app-menu-icon > StIcon,
+      .popup-menu-arrow {
+        icon-shadow: none;
+      }
     }
 
     &:active, &:overview, &:focus, &:checked {


### PR DESCRIPTION
Ok - this is a PR from the text file here https://github.com/horst3180/arc-theme/issues/824#issuecomment-341837920

I'm not a GNOME-Shell person so I'm not really sure what I'm suppose to be looking for.

@NicoHood any chance you can check this PR?

https://github.com/NicoHood/arc-theme/issues/69