### PR TITLE
Scaled down Thunar navigation icons (please see screenshots)

### DIFF
--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -163,6 +163,10 @@ $disk_space_free: darken($bg_color, 3%);
 // Thunar
 //
 .thunar {
+  toolbar.horizontal button image {
+    -gtk-icon-transform: scale(0.8);
+  }
+
   scrolledwindow.sidebar {
     border-top: 1px solid $borders_color;
     treeview.view {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/18384371/42126486-73a3f51c-7c57-11e8-96d4-e790de9e0cac.png)

After:
![image](https://user-images.githubusercontent.com/18384371/42126466-3ec2befa-7c57-11e8-9044-0e353a9aea05.png)