### PR TITLE
Add optipng package in manual installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ To build the theme the following packages are required
 * `pkg-config` or `pkgconfig` for Fedora
 * `libgtk-3-dev` for Debian based distros or `gtk3-devel` for RPM based distros
 * `git` to clone the source directory
+* `optipng`
 
 **Note:** For distributions which don't ship separate development packages, just the GTK 3 package is needed instead of the `-dev` packages.
 


### PR DESCRIPTION
I'm on Ubuntu 16.04. There are warning output in here

```shell
Rendering assets/arrow-down.png
./render-assets.sh: line 25: /usr/bin/optipng: No such file or directory

Rendering assets-dark/arrow-down.png
./render-assets.sh: line 36: /usr/bin/optipng: No such file or directory
```

It seems that `optipng` is not installed by default in Ubuntu. In the README file, you may have to add it in manual installation