### PR TITLE
Fix gnome-shell switches and checkboxes

### DIFF
--- a/common/gnome-shell/3.18/common-assets/switch/switch-off-selected.svg
+++ b/common/gnome-shell/3.18/common-assets/switch/switch-off-selected.svg
@@ -23,7 +23,7 @@
        id="selected_fg_color"
        osb:paint="solid">
       <stop
-         style="stop-color:#ffffffgit;stop-opacity:1;"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
          id="stop4164" />
     </linearGradient>

--- a/common/gnome-shell/3.18/common-assets/switch/switch-on-selected.svg
+++ b/common/gnome-shell/3.18/common-assets/switch/switch-on-selected.svg
@@ -23,7 +23,7 @@
        id="selected_fg_color"
        osb:paint="solid">
       <stop
-         style="stop-color:#ffffffgit;stop-opacity:1;"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
          id="stop4171" />
     </linearGradient>

--- a/common/gnome-shell/3.18/light-assets/checkbox/checkbox-checked-focused.svg
+++ b/common/gnome-shell/3.18/light-assets/checkbox/checkbox-checked-focused.svg
@@ -26,7 +26,7 @@
        id="selected_fg_color"
        osb:paint="solid">
       <stop
-         style="stop-color:#ffffffgit;stop-opacity:1;"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
          id="stop4169" />
     </linearGradient>

--- a/common/gnome-shell/3.18/light-assets/checkbox/checkbox-checked.svg
+++ b/common/gnome-shell/3.18/light-assets/checkbox/checkbox-checked.svg
@@ -26,7 +26,7 @@
        id="selected_fg_color"
        osb:paint="solid">
       <stop
-         style="stop-color:#ffffffgit;stop-opacity:1;"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
          id="stop4169" />
     </linearGradient>

--- a/common/gnome-shell/3.18/light-assets/misc/message-close-active.svg
+++ b/common/gnome-shell/3.18/light-assets/misc/message-close-active.svg
@@ -24,7 +24,7 @@
        id="selected_fg_color"
        osb:paint="solid">
       <stop
-         style="stop-color:#ffffffgit;stop-opacity:1;"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
          id="stop4157" />
     </linearGradient>

--- a/common/gnome-shell/3.18/light-assets/switch/switch-on.svg
+++ b/common/gnome-shell/3.18/light-assets/switch/switch-on.svg
@@ -23,7 +23,7 @@
        id="selected_fg_color"
        osb:paint="solid">
       <stop
-         style="stop-color:#ffffffgit;stop-opacity:1;"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
          id="stop4181" />
     </linearGradient>


### PR DESCRIPTION
I think it is pretty self-explanatory, it affected only the light theme

Before
![schermata da 2018-07-17 18-10-04](https://user-images.githubusercontent.com/29411952/42841104-4b231f86-8a09-11e8-8a78-380e8f592b8f.png)
After
![schermata da 2018-07-17 18-16-20](https://user-images.githubusercontent.com/29411952/42841204-9ea3e46a-8a09-11e8-8770-d40cf1a81ac8.png)
