### PR TITLE
Increase default font size to 10 for CSS themes

### DIFF
--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -206,7 +206,7 @@ StScrollBar {
 
   StLabel {
     padding-top: 4px;
-    font-size: 0.9em;
+    @include fontsize($font-size);
     box-shadow: none;
   }
 
@@ -259,7 +259,7 @@ StScrollBar {
   padding: 5px 12px;
   background-color: $osd_bg_color;
   color: $osd_fg_color;
-  font-size: 1em;
+  @include fontsize($font-size);
   font-weight: normal;
   text-align: center;
 }
@@ -417,7 +417,7 @@ StScrollBar {
 
   &-top, &-bottom, &-left, &-right {
     color: $_panel_fg_color;
-    font-size: 1em;
+    @include fontsize($font-size);
     padding: 0px;
   }
 
@@ -470,7 +470,7 @@ StScrollBar {
   color: $osd_fg_color;
   spacing: 25px;
   border-radius: 2px;
-  font-size: 9pt;
+  @include fontsize($font-size);
   padding: 5px 8px;
   -cinnamon-caption-spacing: 4px;
 
@@ -486,7 +486,7 @@ StScrollBar {
 .expo-workspaces-name-entry#selected {
   height: 15px;
   border-radius: 2px;
-  font-size: 9pt;
+  @include fontsize($font-size);
   padding: 5px 8px;
   -cinnamon-caption-spacing: 4px;
   @include entry(osd);
@@ -593,11 +593,11 @@ StScrollBar {
     padding-bottom: 10px;
   }
   &-title {
-    font-size: 2em;
+    @include fontsize($font-size * 2);
     font-weight: bold;
   }
   &-uuid {
-    font-size: 10px;
+    @include fontsize($font-size * 0.83);
     color: #888;
   }
   &-icon {
@@ -623,7 +623,7 @@ StScrollBar {
   }
   &-version {
     padding-left: 7px;
-    font-size: 10px;
+    @include fontsize($font-size * 0.83);
     color: #888;
   }
 }
@@ -693,7 +693,7 @@ StScrollBar {
 }
 
 .calendar-day-base {
-  font-size: 80%;
+  @include fontsize($font-size * 0.875);
   text-align: center;
   width: 25px;
   height: 25px;
@@ -705,7 +705,7 @@ StScrollBar {
 .calendar-day-heading {
   color: transparentize($fg_color, 0.15);
   margin-top: 1em;
-  font-size: 70%;
+  @include fontsize($font-size * 0.75);
 }
 
 .calendar-day {
@@ -744,7 +744,7 @@ StScrollBar {
 
 .calendar-week-number {
   color: transparentize($fg_color, 0.3);
-  font-size: 80%;
+  @include fontsize($font-size * 0.75);
 }
 
 //
@@ -955,7 +955,7 @@ StScrollBar {
   }
   &-completion-box {
     padding-left: 15px;
-    font-size: 10px;
+    @include fontsize($font-size * 0.83);
   }
   &-entry {
     width: 21em;
@@ -1030,7 +1030,7 @@ StScrollBar {
     &-icon:ltr { padding-right: 17px; }
     &-icon:rtl { padding-left: 17px; }
 
-    &-name { font-size: 1.1em; }
+    &-name { @include fontsize($font-size * 1.1); }
   }
 }
 
@@ -1065,7 +1065,7 @@ StScrollBar {
 .keyboard-key {
   min-height: 2em;
   min-width: 2em;
-  font-size: 14pt;
+  @include fontsize($font-size * 1.56);
   font-weight: bold;
   border-radius: 3px;
   box-shadow: none;
@@ -1234,7 +1234,7 @@ StScrollBar {
   border-radius: 5px;
   border-image: url("common-assets/misc/osd.svg") 9 9 9 9;
 
-.osd-monitor-label { font-size: 3em; }
+.osd-monitor-label { @include fontsize($font-size * 3); }
 
   .level {
     padding: 0;
@@ -1602,7 +1602,7 @@ StScrollBar {
 
 .user-label {
     color: $fg_color;
-    font-size: 1em;
+    @include fontsize($font-size);
     font-weight: bold;
     margin: 0px;
 }
@@ -1643,7 +1643,7 @@ StScrollBar {
   &-header {
     border-image: url("common-assets/misc/desklet-header.svg") 9 9 9 9;
     color: $osd_fg_color;
-    font-size: 1em;
+    @include fontsize($font-size);
     padding: 12px;
     padding-bottom: 6px;
   }
@@ -1668,7 +1668,7 @@ StScrollBar {
   /*color: red;*/
   text-shadow: black 5px 5px 5px;
   font-weight: bold;
-  font-size: 48pt;
+  @include fontsize($font-size * 5.33);
 }
 
 //

--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -3,7 +3,7 @@ $asset_path: if($variant == 'dark', dark-assets, light-assets);
 //
 // Globals
 //
-$font-size: 9;
+$font-size: 10;
 $font-family: Futura Bk bt, sans, Sans-Serif;
 $_bubble_bg_color: opacify($osd_bg_color,0.25);
 $_bubble_fg_color: $osd_fg_color;

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -25,7 +25,7 @@ $asset_path: if($variant == 'dark', dark-assets, light-assets);
 //
 // Globals
 //
-$font-size: 9;
+$font-size: 10;
 $font-family: Futura Bk bt, Cantarell, Sans-Serif;
 $_bubble_bg_color: opacify($osd_bg_color,0.25);
 $_bubble_fg_color: $osd_fg_color;

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -207,7 +207,7 @@ StScrollBar {
 //
 // Modal Dialogs
 //
-.headline { font-size: 110%; }
+.headline { @include fontsize($font-size * 1.1); }
 .lightbox { background-color: black; }
 .flashspot { background-color: white; }
 
@@ -722,7 +722,7 @@ StScrollBar {
   border-radius: 5px;
   border-image: url("common-assets/misc/osd.svg") 9 9 9 9;
 
-.osd-monitor-label { font-size: 3em; }
+.osd-monitor-label { @include fontsize($font-size * 3); }
 
   .level {
     padding: 0;
@@ -806,7 +806,7 @@ StScrollBar {
 }
 
 .input-source-switcher-symbol {
-  font-size: 34pt;
+  @include fontsize($font-size * 4);
   width: 96px;
   height: 96px;
 }
@@ -1137,7 +1137,7 @@ StScrollBar {
 }
 
 .datemenu-today-button .date-label {
-  font-size: 1.5em;
+  @include fontsize($font-size * 1.5);
 }
 
 .world-clocks-header,
@@ -1212,7 +1212,7 @@ StScrollBar {
 }
 
 .calendar-day-base {
-  font-size: 80%;
+  @include fontsize($font-size * 0.875);
   text-align: center;
   width: 25px; height: 25px;
   padding: 0.1em;
@@ -1230,7 +1230,7 @@ StScrollBar {
   &.calendar-day-heading {  //day of week heading
     color: transparentize($fg_color, 0.15);
     margin-top: 1em;
-    font-size: 70%;
+    @include fontsize($font-size * 0.75);
   }
 }
 
@@ -1274,7 +1274,7 @@ StScrollBar {
 }
 
 .calendar-week-number {
-  font-size: 70%;
+  @include fontsize($font-size * 0.75);
   font-weight: bold;
   width: 2.3em; height: 1.8em;
   border-radius: 2px;
@@ -1359,7 +1359,7 @@ StScrollBar {
   &-secondary-bin,
   &-secondary-bin > .event-time {
     color: transparentize($fg_color, 0.4);
-    font-size: 0.9em;
+    @include fontsize($font-size * 0.9);
 
     &:ltr { padding-left: 8px; }
     &:rtl { padding-right: 8px; }
@@ -1375,14 +1375,14 @@ StScrollBar {
   &-title {
     color: inherit;
     font-weight: bold;
-    font-size: 1em;
+    @include fontsize($font-size);
     padding: 2px 0 2px 0;
   }
 
   &-content {
     color: inherit;
     padding: 8px;
-    font-size: 1em;
+    @include fontsize($font-size);
   }
 }
 
@@ -1479,7 +1479,7 @@ StScrollBar {
   &-airplane-box { spacing: 12px; }
 
   &-airplane-headline {
-    font-size: 1.1em;
+    @include fontsize($font-size * 1.1);
     font-weight: bold;
     text-align: center;
   }
@@ -1496,11 +1496,11 @@ StScrollBar {
 
   &-header {
     font-weight: bold;
-    font-size: 1.2em;
+    @include fontsize($font-size * 1.2);
   }
 
   &-item {
-    font-size: 1em;
+    @include fontsize($font-size);
     border-bottom: 0px solid;
     padding: 12px;
     spacing: 0px;
@@ -1631,7 +1631,7 @@ StScrollBar {
 // Dash
 //
 #dash {
-  font-size: 1em;
+  @include fontsize($font-size);
   color: $osd_fg_color;
   background-color: $dark_sidebar_bg;
   border-color: rgba(0,0,0,0.4);
@@ -1940,7 +1940,7 @@ StScrollBar {
 }
 
 %status_text {
-  font-size: 2em;
+  @include fontsize($font-size * 2);
   font-weight: bold;
   color: $fg_color;
 }
@@ -1954,7 +1954,7 @@ StScrollBar {
 .notification-banner,
 .notification-banner:hover,
 .notification-banner:focus {
-  font-size: 1em;
+  @include fontsize($font-size);
   width: 34em;
   margin: 5px;
   padding: 10px;
@@ -2004,7 +2004,7 @@ StScrollBar {
 
 .chat-meta-message {
   padding-left: 4px;
-  font-size: 9pt;
+  @include fontsize($font-size);
   font-weight: bold;
   color: transparentize($fg_color, 0.4);
 
@@ -2118,7 +2118,7 @@ $legacy_icon_size: 24px;
 .keyboard-key {
   min-height: 2em;
   min-width: 2em;
-  font-size: 14pt;
+  @include fontsize($font-size * 1.56);
   font-weight: bold;
   border-radius: 3px;
   box-shadow: none;
@@ -2150,7 +2150,7 @@ $legacy_icon_size: 24px;
   padding: 0.5em;
   spacing: 0.3em;
   color: $osd_fg_color;
-  font-size: 1.15em;
+  @include fontsize($font-size * 1.15);
 }
 
   .candidate-index {
@@ -2234,7 +2234,7 @@ $legacy_icon_size: 24px;
     }
   }
   .login-dialog-not-listed-label {
-    font-size: 90%;
+    @include fontsize($font-size * 0.9);
     font-weight: bold;
     color: darken($osd_fg_color,30%);
     padding-top: 1em;
@@ -2266,7 +2266,7 @@ $legacy_icon_size: 24px;
   .login-dialog-username,
   .user-widget-label {
     color: $osd_fg_color;
-    font-size: 120%;
+    @include fontsize($font-size * 1.2);
     font-weight: bold;
     text-align: left;
     padding-left: 15px;
@@ -2285,7 +2285,7 @@ $legacy_icon_size: 24px;
 
   .login-dialog-prompt-label {
     color: darken($osd_fg_color, 20%);
-    font-size: 110%;
+    @include fontsize($font-size 1.1);
     padding-top: 1em;
   }
 
@@ -2323,11 +2323,11 @@ $legacy_icon_size: 24px;
 }
 
 .screen-shield-clock-time {
-  font-size: 72pt;
+  @include fontsize($font-size * 8);
   text-shadow: 0px 2px 2px rgba(0,0,0,0.4);
 }
 
-.screen-shield-clock-date { font-size: 28pt; }
+.screen-shield-clock-date { @include fontsize($font-size * 3); }
 
 .screen-shield-notifications-container {
   spacing: 6px;
@@ -2443,7 +2443,7 @@ $legacy_icon_size: 24px;
 }
 
 .lg-completions-text {
-  font-size: .9em;
+  @include fontsize($font-size * 0.9);
   font-style: italic;
 }
 


### PR DESCRIPTION
Make elements such as: panels, application menus, pop-up notifications,
and left/right-click menus easier to read across a broader array of
fonts.

Fixes #105