### PR TITLE
Fix mismatched "}" for GNOME 3.18 NEW

### DIFF
--- a/common/gtk-3.0/3.18/sass/_common.scss
+++ b/common/gtk-3.0/3.18/sass/_common.scss
@@ -2898,6 +2898,7 @@ GtkVolumeButton.button { padding: 8px; }
       }
     }
   }
+  }
 }
 
 // catch all extend


### PR DESCRIPTION
Rebased #111  