### PR TITLE
Display horizontal separators

### DIFF
--- a/common/gtk-3.0/3.20/sass/_colors.scss
+++ b/common/gtk-3.0/3.20/sass/_colors.scss
@@ -15,6 +15,7 @@ $selected_fg_color: #ffffff;
 $selected_bg_color: #5294e2;
 $selected_borders_color: darken($selected_bg_color, 20%);
 $borders_color: if($variant =='light', darken($bg_color,9%), darken($bg_color,6%));
+$horizontal_separators_color: if($variant == 'light', $borders_color, darken($fg_color,50%));
 
 $link_color: if($variant == 'light', darken($selected_bg_color,10%),
                                      lighten($selected_bg_color,20%));

--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -1616,13 +1616,8 @@ menu,
   separator,
   .csd & separator {
     margin: 2px 0;
-    background-color: $_menu_bg;
+    background-color: $horizontal_separators_color;
   }
-
-  // Firefox workaround
-  .separator:not(label),
-  .csd & .separator:not(label) { color: $_menu_bg; }
-  // Firefox workaround end
 
   menuitem {
     min-height: 16px;

--- a/common/gtk-3.0/_colors.scss.thpl
+++ b/common/gtk-3.0/_colors.scss.thpl
@@ -17,6 +17,7 @@ $selected_fg_color: %SEL_FG%;
 $selected_bg_color: %SEL_BG%;
 $selected_borders_color: darken($selected_bg_color, 20%);
 $borders_color: if($variant =='light', darken($bg_color,9%), darken($bg_color,6%));
+$horizontal_separators_color: if($variant == 'light', $borders_color, darken($fg_color,50%));
 
 $link_color: if($variant == 'light', darken($selected_bg_color,10%),
                                      lighten($selected_bg_color,20%));


### PR DESCRIPTION
As requested in #114, I created a workaround to show horizontal separators in Firefox.

After activating it, the separators are also shown in Nautilus + Thundebird