### PR TITLE
Fixing MATE panel icon spacing issues.

### DIFF
--- a/common/gtk-3.0/3.18/sass/_applications.scss
+++ b/common/gtk-3.0/3.18/sass/_applications.scss
@@ -575,7 +575,7 @@ WnckPager {
 }
 
 NaTrayApplet {
-  -NaTrayApplet-icon-padding: 12;
+  -NaTrayApplet-icon-padding: 0;
   -NaTrayApplet-icon-size: 16;
 }
 


### PR DESCRIPTION
This should hopefully fix any of those MATE padding issues that I've been experiencing, although there might have been some update that fixed them on MATE's end (I'm not sure, as I still encounter it with other systems running what I think is the same version.) 

Anyway, I just copied the padding settings over from the gtk 3.20 side, and after a quick test it runs on my Linux Mint 18.3 MATE machine without weird padding problems. Not sure about other DE's as I run exclusively MATE.