### PR TITLE
No need to keep rendering GTK+3 assets

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -35,3 +35,5 @@ Because this theme is heavily based on the pixmap engine, a lot of the styling c
 * Save `assets.svg` and delete the images corresponding to the edited .svg objects from the `assets` folder (or just delete everything in the `assets` folder)
 
 * Run `./render-assets.sh` or `./render-dark-assets.sh` from a terminal
+
+* N.B. If you are making color changes then remove the contents of the folders gtk-2.0/assets/* gtk-2.0/assets-dark and the assets folder under the GTK+3 folder that the theme is compiled for

--- a/common/gtk-3.0/3.20/render-asset.sh
+++ b/common/gtk-3.0/3.20/render-asset.sh
@@ -9,15 +9,20 @@ ASSETS_DIR="assets"
 
 i="$1"
 
-echo "Rendering '$ASSETS_DIR/$i.png'"
-"$INKSCAPE" --export-id="$i" \
-            --export-id-only \
-            --export-png="$ASSETS_DIR/$i.png" "$SRC_FILE" >/dev/null \
-&& "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i.png"
+result_file="$ASSETS_DIR/$i.png"
+if [[ -f "${result_file}" ]] ; then
+	echo "${result_file} already exists."
+else
+	echo "Rendering '$ASSETS_DIR/$i.png'"
+	"$INKSCAPE" --export-id="$i" \
+	            --export-id-only \
+	            --export-png="$ASSETS_DIR/$i.png" "$SRC_FILE" >/dev/null \
+	&& "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i.png"
 
-echo "Rendering '$ASSETS_DIR/$i@2.png'"
-"$INKSCAPE" --export-id="$i" \
-            --export-id-only \
-            --export-dpi=192 \
-            --export-png="$ASSETS_DIR/$i@2.png" "$SRC_FILE" >/dev/null \
-&& "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i@2.png"
+	echo "Rendering '$ASSETS_DIR/$i@2.png'"
+	"$INKSCAPE" --export-id="$i" \
+	            --export-id-only \
+	            --export-dpi=192 \
+	            --export-png="$ASSETS_DIR/$i@2.png" "$SRC_FILE" >/dev/null \
+	&& "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i@2.png"
+fi


### PR DESCRIPTION
Unless someone can think of a good reason,  I don't think there is any need to keep rendering GTK+3 assets all the time i.e. once generated then skip the generation.

Speeds up development.