### PR TITLE
Fix thunar sidebar top border color

### DIFF
--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -183,6 +183,10 @@ $disk_space_free: darken($bg_color, 3%);
     @extend %header_widgets;
   }
 
+  scrolledwindow.sidebar {
+    border-top-color: darken($dark_sidebar_bg, 6%);
+  }
+
   scrolledwindow.sidebar treeview.view {
     background: $dark_sidebar_bg;
     color: $dark_sidebar_fg;


### PR DESCRIPTION
A top border was added to the sidebar in Thunar by commit [7c117440c6d2a217f7055a60b3a223585e0f53a2](https://github.com/xfce-mirror/thunar/commit/7c117440c6d2a217f7055a60b3a223585e0f53a2), causing a white top border when using Arc-darker.
![example](https://user-images.githubusercontent.com/5833571/46141286-cf40ba80-c253-11e8-8845-6a9b7fe66992.png)

I don't know if the application specific fix in this pull request is a correct one. Or should this be fixed somewhere around __common.scss:141?

Result:
![image](https://user-images.githubusercontent.com/5833571/46141271-be904480-c253-11e8-9e1d-0a2bff7c4388.png)