### PR TITLE
Nautilus 3.30 pathbar update

### DIFF
--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -69,7 +69,7 @@ terminal-window,
 // Pathbar for nautilus >=3.30
 .nautilus-window .path-bar>box>button {
   margin: 0 4px;
-  padding: 0 2px;
+  padding: 2px;
 }
 
 button.nautilus-circular-button.image-button {

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -66,6 +66,12 @@ terminal-window,
   background-color: $base_color;
 }
 
+// Pathbar for nautilus >=3.30
+.nautilus-window .path-bar>box>button {
+  margin: 0 4px;
+  padding: 0 2px;
+}
+
 button.nautilus-circular-button.image-button {
   @extend button.circular;
 }

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -67,7 +67,7 @@ terminal-window,
 }
 
 // Pathbar for nautilus >=3.30
-.nautilus-window .path-bar>box>button {
+.nautilus-window .path-bar > box > button {
   margin: 0 4px;
   padding: 2px;
 }


### PR DESCRIPTION
Update nautilus pathbar for 3.30 redesign, as discussed in #124 

![screenshot from 2018-09-30 23-33-47](https://user-images.githubusercontent.com/39574454/46262461-51f29f80-c50a-11e8-81e0-b3de3a589728.png)
![screenshot from 2018-09-30 23-33-42](https://user-images.githubusercontent.com/39574454/46262462-51f29f80-c50a-11e8-865c-0caef0512ac6.png)

This works for now, but the pathbar should probably still get properly redesigned based on Adwaita.
For that reason it may make sense to leave #124 open until the redesign.