### PR TITLE
Update documentation for gtk3, gnome-shell and parallel dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To build the theme the following packages are required
 * `inkscape`
 
 The following packages are optionally required
+* `parallel` for speeding up build by rendering assets in parallel
 * `gnome-shell`for auto-detecting the GNOME Shell version
 * `libgtk-3-dev` for Debian based distros or `gtk3-devel` for RPM based distros, for auto-detecting the GTK3 version
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ To build the theme the following packages are required
 * `automake`
 * `sassc`
 * `pkg-config` or `pkgconfig` for Fedora
-* `libgtk-3-dev` for Debian based distros or `gtk3-devel` for RPM based distros
 * `git` to clone the source directory
 * `optipng`
-*  `inkscape`
+* `inkscape`
+
+The following packages are optionally required
+* `gnome-shell`for auto-detecting the GNOME Shell version
+* `libgtk-3-dev` for Debian based distros or `gtk3-devel` for RPM based distros, for auto-detecting the GTK3 version
 
 **Note:** For distributions which don't ship separate development packages, just the GTK 3 package is needed instead of the `-dev` packages.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To build the theme the following packages are required
 **Note:** For distributions which don't ship separate development packages, just the GTK 3 package is needed instead of the `-dev` packages.
 
 For the theme to function properly, install the following
-* GNOME Shell 3.18 - 3.26, GTK 3.18 - 3.22
+* GNOME Shell 3.18 - 3.30, GTK 3.18 - 3.24
 * The `gnome-themes-extra` package
 * The murrine engine. This has different names depending on the distro.
   * `gtk-engine-murrine` (Arch Linux)

--- a/m4/arc-gnome-shell.m4
+++ b/m4/arc-gnome-shell.m4
@@ -16,13 +16,15 @@ AC_DEFUN([ARC_GNOME_SHELL], [
             [no]
         )
         AS_IF(
+            # Couldn't find gnome-shell from $PATH
             [test "x$GNOME_SHELL_FOUND" = xyes],
             [GNOME_SHELL_VERSION=`gnome-shell --version | cut -d' ' -f3`],
-            [AC_MSG_ERROR([Could not find gnome-shell from \$PATH.])]
+            [AC_MSG_ERROR([Could not determine GNOME Shell version. Install gnome-shell, or specify the version using '--with-gnome-shell=<version>' option.])]
         )
         AS_IF(
+            # Found gnome-shell, but couldn't determine the version
             [test -z "$GNOME_SHELL_VERSION"],
-            [AC_MSG_ERROR([Could not determine gnome-shell version.])]
+            [AC_MSG_ERROR([Could not determine GNOME Shell version. Try specifying the version using '--with-gnome-shell=<version>' option.])]
         )]
     )
 

--- a/m4/arc-gtk3.m4
+++ b/m4/arc-gtk3.m4
@@ -13,7 +13,7 @@ AC_DEFUN([ARC_GTK3], [
         [PKG_CHECK_EXISTS(
             [gtk+-3.0],
             [GTK3_VERSION=`$PKG_CONFIG --modversion gtk+-3.0`],
-            [AC_MSG_ERROR([Could not determine GTK3 version. Install GTK3 and its development files (libgtk-3-dev for Debian/Ubuntu based distros and gtk3-devel for RPM based distros).])]
+            [AC_MSG_ERROR([Could not determine GTK3 version. Install GTK3 and its development files (libgtk-3-dev for Debian/Ubuntu based distros and gtk3-devel for RPM based distros), or specify the version using '--with-gtk3=<version>' option.])]
         )]
     )
 


### PR DESCRIPTION
This updates dependency information in README regarding gnome-shell and gtk3 version auto-detection, and also improves error output from autoconf macros when autodetection fails.

English isn't my first language, so it's possible the grammar could be improved. Let me know if something seems funny, or could be explained clearer.

Hopefully this prevents user confusion, such as in #136