### PR TITLE
Nautilus 3.30 path-bar redesign

### DIFF
--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -67,12 +67,12 @@ terminal-window,
 }
 
 // Pathbar for nautilus >=3.30
-.nautilus-window .path-bar-box {
+.nautilus-window .path-bar-box.width-maximized {
+  border: 1px $header_button_border solid;
   border-radius: 3px;
 
-  &.frame {
+  &:not(:backdrop) {
     background-color: $header_button_bg;
-    border-color: $header_button_border;
   }
 }
 .nautilus-window .path-bar > box > button {

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -67,9 +67,25 @@ terminal-window,
 }
 
 // Pathbar for nautilus >=3.30
+.nautilus-window .path-bar-box {
+  border-radius: 3px;
+
+  &.frame {
+    background-color: $header_button_bg;
+    border-color: $header_button_border;
+  }
+}
 .nautilus-window .path-bar > box > button {
-  margin: 0 4px;
-  padding: 2px;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 0;
+  color: $header_fg;
+  margin: 0 2px;
+  padding: 1px;
+
+  &:not(:backdrop):hover {
+    box-shadow: 0 -3px $selected_bg_color inset;
+  }
 }
 
 button.nautilus-circular-button.image-button {

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -70,6 +70,8 @@ terminal-window,
 .nautilus-window .path-bar-box.width-maximized {
   border: 1px $header_button_border solid;
   border-radius: 3px;
+  transition: border $backdrop_transition;
+  transition: background-color $backdrop_transition;
 
   &:not(:backdrop) {
     background-color: $header_button_bg;


### PR DESCRIPTION
Properly theme the redesigned path-bar in nautilus 3.30, as discussed in #133.

Closes #133 and #139 