### PR TITLE
Workaround gnome-shell 3.30 popup-sub-menu glitch

### DIFF
--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -623,9 +623,15 @@ StScrollBar {
 
   .popup-menu-arrow { } //defined globally in the TOP BAR
   .popup-sub-menu {
-    background: none;
-    box-shadow: none;
-    border-image: url("#{$asset_path}/menu/submenu.svg") 9 9 9 9;
+    background: if($variant=='light', rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.15));
+    box-shadow: inset 0 -1px if($variant=='light', rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.15));
+    margin: 0 4px;
+
+    .popup-menu-item.selected {
+      background-color: $selected_bg_color;
+      border-image: none;
+      margin: 0;
+    }
   }
 
   .popup-menu-content { padding: 1em 0em 1em 0em; }


### PR DESCRIPTION
Closes https://github.com/NicoHood/arc-theme/issues/135

Workaround the glitch described in #135 by not using svg assets in `border-image` for drawing the `popup-sub-menu` backgrounds, but use plain css instead.

Unfortunately this isn't 100% pixel-perfect workaround, since the text in menu items inside popup-sub-menus is moved 4px right. However I think that wasn't aligned with anything, so the change should be barely noticeable, as seen with "Turn Off" and "Wired Settings" labels below.

Before:
![screenshot from 2018-10-12 05-25-48](https://user-images.githubusercontent.com/39574454/46844660-bbaf5b00-cde0-11e8-9995-00b36a163424.png)
After:
![screenshot from 2018-10-12 05-23-08](https://user-images.githubusercontent.com/39574454/46844669-c23dd280-cde0-11e8-8b83-ff32d1a1bca0.png)

Apart from the text align, everything should look exactly as it did before this change.