### PR TITLE
Change the color of seperators in context menus

### DIFF
--- a/common/gtk-3.0/3.20/sass/_colors.scss
+++ b/common/gtk-3.0/3.20/sass/_colors.scss
@@ -15,7 +15,7 @@ $selected_fg_color: #ffffff;
 $selected_bg_color: #5294e2;
 $selected_borders_color: darken($selected_bg_color, 20%);
 $borders_color: if($variant =='light', darken($bg_color,9%), darken($bg_color,6%));
-$horizontal_separators_color: if($variant == 'light', $borders_color, darken($fg_color,50%));
+$horizontal_separators_color: if($variant == 'light', $borders_color, mix(white,$borders_color,1%));
 
 $link_color: if($variant == 'light', darken($selected_bg_color,10%),
                                      lighten($selected_bg_color,20%));


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/5961244/47379044-1bb7d280-d6fa-11e8-824a-068bee15d651.png)

After:

![after](https://user-images.githubusercontent.com/5961244/47379050-1f4b5980-d6fa-11e8-92e1-65706326330a.png)
