### PR TITLE
Some fixes for Cinnamon

### DIFF
--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -1277,6 +1277,7 @@ StScrollBar {
     padding-top: 0;
     padding-left: 8px;
     padding-right: 8px;
+    spacing: 4px;
     transition-duration: 100;
     color: transparentize($_shell_fg_color, 0.4);
 
@@ -1547,6 +1548,7 @@ StScrollBar {
   &-box {
     padding-left: 3px;
     padding-right: 3px;
+    spacing: 4px;
     color: $_shell_fg_color;
     text-shadow: none;
     transition-duration: 100;

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -753,7 +753,7 @@ panel-toplevel.background {
 //
 // Floating Bar
 //
-.nautilus-window .floating-bar {
+.nautilus-window .floating-bar, .nemo-window .floating-bar {
   padding: 1px;
   background-color: $selected_bg_color;
   color: $selected_fg_color;


### PR DESCRIPTION
This should fix the missing style for Nemo's floating bar and add spacing to Cinnamon theme to make it look nicer.

Before:
![nemo-before](https://user-images.githubusercontent.com/2252500/47806380-9923b880-dd74-11e8-8a8e-1b711bf6bf2f.png)
![cinnamon-before](https://user-images.githubusercontent.com/2252500/47806278-54981d00-dd74-11e8-868c-6f904e7d2858.png)

After:
![nemo-after](https://user-images.githubusercontent.com/2252500/47806296-5c57c180-dd74-11e8-959e-b245e7dc7a5f.png)
![cinnamon-after](https://user-images.githubusercontent.com/2252500/47806307-6083df00-dd74-11e8-94e4-9789e9e991f3.png)
