### PR TITLE
Fix horizontal stepper icons (GTK3)

### DIFF
--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -1892,8 +1892,8 @@ scrollbar {
   }
 
   &.horizontal button {
-    &.down { -gtk-icon-source: -gtk-icontheme('pan-right-symbolic'); }
-    &.up { -gtk-icon-source: -gtk-icontheme('pan-left-symbolic'); }
+    &.down { -gtk-icon-source: -gtk-icontheme('pan-end-symbolic'); }
+    &.up { -gtk-icon-source: -gtk-icontheme('pan-start-symbolic'); }
   }
 
   // slider


### PR DESCRIPTION
Steppers are disabled by default but the icons nevertheless get overridden in the css, causing issues to those re-enabling them due to incorrect icon names being used for the horizontal steppers.