### PR TITLE
Nemo - distinguish inactive pane in dual pane mode.

### DIFF
--- a/common/gtk-3.0/3.18/sass/_applications.scss
+++ b/common/gtk-3.0/3.18/sass/_applications.scss
@@ -196,6 +196,11 @@ NemoWindow {
         &:last-child:hover { box-shadow: inset 1px 0 $_linked_separator_color; }
     }
   }
+  
+  .nemo-inactive-pane .view, .nemo-inactive-pane iconview {
+    color: $insensitive_fg_color;
+    background-color: $base_color;
+  }
 }
 
 //

--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -181,6 +181,13 @@ $disk_space_free: darken($bg_color, 3%);
 
     @include pathbar_linking_rules($sep_color:$header_button_border);
   }
+  
+  // Nemo dual pane inactive pane
+  
+  .nemo-inactive-pane .view {
+    color: $insensitive_fg_color;
+    background-color: $base_color;
+  }
 }
 
 //


### PR DESCRIPTION
Hi,

This PR distinguishes the inactive pane in nemo dual pane mode by using the insensitive fg text color for that pane. In screenshots below the left pane is active.

Before
![screenshot-window-2019-02-10-111412](https://user-images.githubusercontent.com/29017677/52533007-597e4c80-2d25-11e9-8d42-277bb215c281.png)

After
![screenshot-window-2019-02-10-110131](https://user-images.githubusercontent.com/29017677/52533008-5edb9700-2d25-11e9-86b4-d11be52ea797.png)
