### PR TITLE
Cinnamon - calendar alignment improvements

### DIFF
--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -705,19 +705,19 @@ StScrollBar {
 .calendar-day-base {
   font-size: 80%;
   text-align: center;
-  width: 25px;
-  height: 25px;
+  width: 2.5em;
+  height: 2.5em;
   padding: 0.1em;
-  margin: 2px;
-  border-radius: 12.5px;
+  margin: 0.1em;
+  border-radius: 999px;
 }
 
 .calendar-day-heading {
   color: transparentize($fg_color, 0.15);
   margin-top: 1em;
   font-size: 70%;
-  width: 25px;
-  height: 20px;
+  width: 2.5em;
+  height: 2em;
 }
 
 .calendar-day {
@@ -758,9 +758,9 @@ StScrollBar {
 .calendar-week-number {
   color: transparentize($fg_color, 0.3);
   font-size: 80%;
-  width: 25px;
-  height: 20px;
-  padding: 0.8em 0 0;
+  width: 2.5em;
+  height: 2em;
+  padding: 0.7em 0 0;
   text-align: center;
 }
 

--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -716,6 +716,8 @@ StScrollBar {
   color: transparentize($fg_color, 0.15);
   margin-top: 1em;
   font-size: 70%;
+  width: 25px;
+  height: 20px;
 }
 
 .calendar-day {
@@ -735,6 +737,7 @@ StScrollBar {
   color: $fg_color;
   background-color: transparent;
   font-weight: bold;
+  border-width: 0;
 }
 
 .calendar-today,
@@ -755,6 +758,10 @@ StScrollBar {
 .calendar-week-number {
   color: transparentize($fg_color, 0.3);
   font-size: 80%;
+  width: 25px;
+  height: 20px;
+  padding: 0.8em 0 0;
+  text-align: center;
 }
 
 //


### PR DESCRIPTION
Hi,

Some fixes to the Cinnamon Calendar to better align week numbers and dates.

Before
![screenshot-cinnamon-2019-02-11-084614](https://user-images.githubusercontent.com/29017677/52553139-87719880-2dda-11e9-8a75-26ee49c0c571.png)

After
![screenshot-cinnamon-2019-02-11-091231](https://user-images.githubusercontent.com/29017677/52553950-331be800-2ddd-11e9-8f93-f7a537c0671a.png)

Also it maintains the alignment if users use text scaling values different from 1.

![screenshot-screen-2019-02-11-091149](https://user-images.githubusercontent.com/29017677/52553986-4b8c0280-2ddd-11e9-9562-ca60560e1cd5.png)

