### PR TITLE
Cinnamon popupmenu

### DIFF
--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -289,7 +289,7 @@ StScrollBar {
     }
   }
 
-  .popup-menu-content { padding: 1em 0em 1em 0em; }
+  .popup-menu-content { padding: 1em 1px; }
   .popup-menu-item {
     padding: .4em 1.75em;
     spacing: 1em;

--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -334,11 +334,11 @@ StScrollBar {
 .popup-combobox-item { spacing: 1em; }
 
 .popup-separator-menu-item {
-  -gradient-height: 2px;
-  -gradient-start: transparent;
-  -gradient-end: transparent;
-  -margin-horizontal: 1.5em;
-  height: 1em;
+  -gradient-height: 1px;
+  -gradient-start: $selected_bg_color;
+  -gradient-end: $selected_bg_color;
+  -margin-horizontal: 0;
+  height: 0.5em;
 }
 
 .popup-alternating-menu-item:alternate {

--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -1223,7 +1223,7 @@ StScrollBar {
 
 /* Context menu (at the moment only for favorites) */
 .menu-context-menu {
-  padding: 1em 0.6em;
+  padding: 1em 1px;
 }
 
 //


### PR DESCRIPTION
Hi,

This fixes an issue where the selection highlight on the Cinnamon popupmenu overlays the border image creating a bleeding effect. I've also added a visible popupmenu seperator. I think this does look better on larger more complex popup menus.

Before
![screenshot-area-2019-02-11-093112](https://user-images.githubusercontent.com/29017677/52554810-ee458080-2ddf-11e9-9858-97fe357c30ed.png)

After
![screenshot-area-2019-02-11-093155](https://user-images.githubusercontent.com/29017677/52554825-f9001580-2ddf-11e9-964b-7329d9944409.png)

