### PR TITLE
Cinnamon4 menu - make 'fake' separator arc blue for consistency with older Cinnamon versions

### DIFF
--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -1114,13 +1114,13 @@ StScrollBar {
     transition-duration: 300;
     background-color: $bg_color;
     border: 1px solid $borders_color;
-    spacing: 1em;
+    spacing: 0.5em;
   }
   
   &-favorites-scrollbox {
-    padding-bottom: 1em;
+    padding-bottom: 0.5em;
     border-bottom: 1px solid;
-    border-color: $borders_color;
+    border-color: $selected_bg_color;
   }
   
   &-favorites-button {


### PR DESCRIPTION
Before
![screenshot-cinnamon-2019-02-11-094304](https://user-images.githubusercontent.com/29017677/52555469-c0613b80-2de1-11e9-8263-8a8e51d09acf.png)

After
![screenshot-cinnamon-2019-02-11-094246](https://user-images.githubusercontent.com/29017677/52555482-c9520d00-2de1-11e9-9934-ab00eabc836f.png)
