### PR TITLE
Fix vertical and horizontal levelbar values

### DIFF
--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -2335,7 +2335,7 @@ progressbar {
 levelbar {
   block {
     min-width: 1px;
-    min-height: 32px;
+    min-height: 20px;
   }
   &.vertical block {
     min-width: 32px;

--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -2334,12 +2334,12 @@ progressbar {
 //
 levelbar {
   block {
-    min-width: 32px;
-    min-height: 1px;
-  }
-  &.vertical block {
     min-width: 1px;
     min-height: 32px;
+  }
+  &.vertical block {
+    min-width: 32px;
+    min-height: 1px;
   }
 
   trough {


### PR DESCRIPTION
The horizontal levelbar auto-width and auto-height values were used wrongly for vertical levelbar and vis versa. This lead to a visual minimum load of vertical or and horizontal levelbars.