### PR TITLE
Cinnamon - use borders_color for popup-menu seperator

### DIFF
--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -335,8 +335,8 @@ StScrollBar {
 
 .popup-separator-menu-item {
   -gradient-height: 1px;
-  -gradient-start: $selected_bg_color;
-  -gradient-end: $selected_bg_color;
+  -gradient-start: $borders_color;
+  -gradient-end: $borders_color;
   -margin-horizontal: 0;
   height: 0.5em;
 }


### PR DESCRIPTION
As per discussion https://github.com/NicoHood/arc-theme/pull/190