### PR TITLE
Cinnamon menu - fix search entry not expanding for scaled font sizes

### DIFF
--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -1216,7 +1216,6 @@ StScrollBar {
 
 #menu-search-entry {
   width: 250px;
-  height: 15px;
   font-weight: normal;
   caret-color: $fg_color;
 


### PR DESCRIPTION
This removes the hard-coded height from the Cinnamon menu search box so it can expand if necessary for users who use a font-scaling option for accessibility purposes. It doesn't result in any change at regular font scaling settings.

Before
![screenshot-screen-2019-02-24-100338](https://user-images.githubusercontent.com/29017677/53297804-abda6580-381b-11e9-925e-ce7b6ec9f89c.png)


After
![screenshot-screen-2019-02-24-100435](https://user-images.githubusercontent.com/29017677/53297807-af6dec80-381b-11e9-87c2-846902ffa6cb.png)

