### PR TITLE
adjusting cinnamon panel window-list assets

### DIFF
--- a/common/cinnamon/common-assets/panel/window-list-active-bottom.svg
+++ b/common/cinnamon/common-assets/panel/window-list-active-bottom.svg
@@ -8,7 +8,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90.000000"
@@ -17,7 +16,7 @@
    height="4"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:docname="window-list-active-bottom.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
@@ -32,17 +31,17 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="19.769528"
-     inkscape:cx="6.9341604"
-     inkscape:cy="3.0971298"
+     inkscape:cx="-14.065571"
+     inkscape:cy="6.3329333"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="851"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -81,19 +80,10 @@
        id="selected_bg_color"
        osb:paint="solid">
       <stop
-         style="stop-color:#5294e2;stop-opacity:1;"
+         style="stop-color:#FFFFFF;stop-opacity:1;"
          offset="0"
          id="stop4137" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#selected_bg_color"
-       id="linearGradient4139"
-       x1="14"
-       y1="298"
-       x2="14"
-       y2="300"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata4">
@@ -152,11 +142,11 @@
      id="layer1"
      transform="translate(0,-296)">
     <rect
-       style="opacity:1;fill:url(#linearGradient4139);fill-opacity:1;stroke:none"
+       style="opacity:1;fill:#5294e2;fill-opacity:1;stroke:none;stroke-width:1.52752531"
        id="rect4270-9"
-       width="24"
-       height="2"
-       x="2"
-       y="298" />
+       width="28"
+       height="4"
+       x="0"
+       y="296" />
   </g>
 </svg>

--- a/common/cinnamon/common-assets/panel/window-list-active-left.svg
+++ b/common/cinnamon/common-assets/panel/window-list-active-left.svg
@@ -17,7 +17,7 @@
    height="28"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:docname="window-list-active-left.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
@@ -31,18 +31,18 @@
      borderopacity="1"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="9.884764"
-     inkscape:cx="6.9544689"
-     inkscape:cy="5.3696817"
+     inkscape:zoom="27.958335"
+     inkscape:cx="-19.281658"
+     inkscape:cy="20.863897"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="851"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -78,23 +78,31 @@
   <defs
      id="defs3">
     <linearGradient
-       id="selected_bg_color"
+       id="linearGradient819"
        osb:paint="solid">
       <stop
          style="stop-color:#5294e2;stop-opacity:1;"
+         offset="0"
+         id="stop817" />
+    </linearGradient>
+    <linearGradient
+       id="selected_bg_color"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#FFFFFF;stop-opacity:1;"
          offset="0"
          id="stop4137" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#selected_bg_color"
-       id="linearGradient4139"
-       x1="14"
-       y1="298"
-       x2="14"
-       y2="300"
+       xlink:href="#linearGradient819"
+       id="linearGradient821"
+       x1="274"
+       y1="-1.5"
+       x2="298"
+       y2="-1.5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(272,-300)" />
+       gradientTransform="matrix(1.1666667,0,0,1.3333333,-47.666667,0)" />
   </defs>
   <metadata
      id="metadata4">
@@ -112,7 +120,7 @@
         <dc:source />
         <cc:license
            rdf:resource="" />
-        <dc:title></dc:title>
+        <dc:title />
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -153,12 +161,12 @@
      id="layer1"
      transform="translate(0,-272)">
     <rect
-       style="opacity:1;fill:url(#linearGradient4139);fill-opacity:1;stroke:none"
+       style="opacity:1;fill:url(#linearGradient821);fill-opacity:1;stroke:none;stroke-width:1.52752519"
        id="rect4270-9"
-       width="24"
-       height="2"
-       x="274"
-       y="-2"
-       transform="matrix(0,1,-1,0,0,0)" />
+       width="28"
+       height="4"
+       x="272"
+       y="-4"
+       transform="rotate(90)" />
   </g>
 </svg>

--- a/common/cinnamon/common-assets/panel/window-list-active-right.svg
+++ b/common/cinnamon/common-assets/panel/window-list-active-right.svg
@@ -8,7 +8,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90.000000"
@@ -17,7 +16,7 @@
    height="28"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:docname="window-list-active-right.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
@@ -31,18 +30,18 @@
      borderopacity="1"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="9.884764"
-     inkscape:cx="6.9544689"
-     inkscape:cy="5.3696817"
+     inkscape:zoom="19.769528"
+     inkscape:cx="-22.897077"
+     inkscape:cy="15.482706"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="851"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -81,20 +80,10 @@
        id="selected_bg_color"
        osb:paint="solid">
       <stop
-         style="stop-color:#5294e2;stop-opacity:1;"
+         style="stop-color:#FFFFFF;stop-opacity:1;"
          offset="0"
          id="stop4137" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#selected_bg_color"
-       id="linearGradient4139"
-       x1="14"
-       y1="298"
-       x2="14"
-       y2="300"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(272,-302)" />
   </defs>
   <metadata
      id="metadata4">
@@ -112,7 +101,7 @@
         <dc:source />
         <cc:license
            rdf:resource="" />
-        <dc:title></dc:title>
+        <dc:title />
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -153,12 +142,12 @@
      id="layer1"
      transform="translate(0,-272)">
     <rect
-       style="opacity:1;fill:url(#linearGradient4139);fill-opacity:1;stroke:none"
+       style="opacity:1;fill:#5294e2;fill-opacity:1;stroke:none;stroke-width:1.52752531"
        id="rect4270-9"
-       width="24"
-       height="2"
-       x="274"
+       width="28"
+       height="4"
+       x="272"
        y="-4"
-       transform="matrix(0,1,-1,0,0,0)" />
+       transform="rotate(90)" />
   </g>
 </svg>

--- a/common/cinnamon/common-assets/panel/window-list-active-top.svg
+++ b/common/cinnamon/common-assets/panel/window-list-active-top.svg
@@ -8,7 +8,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90.000000"
@@ -17,7 +16,7 @@
    height="4"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:docname="window-list-active-top.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
@@ -31,18 +30,18 @@
      borderopacity="1"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="19.769528"
-     inkscape:cx="-2.1454696"
-     inkscape:cy="3.0971298"
+     inkscape:zoom="39.539056"
+     inkscape:cx="13.194121"
+     inkscape:cy="3.287591"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="851"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -81,19 +80,10 @@
        id="selected_bg_color"
        osb:paint="solid">
       <stop
-         style="stop-color:#5294e2;stop-opacity:1;"
+         style="stop-color:#FFFFFF;stop-opacity:1;"
          offset="0"
          id="stop4137" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#selected_bg_color"
-       id="linearGradient4139"
-       x1="14"
-       y1="296"
-       x2="14"
-       y2="298"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata4">
@@ -152,11 +142,11 @@
      id="layer1"
      transform="translate(0,-296)">
     <rect
-       style="opacity:1;fill:url(#linearGradient4139);fill-opacity:1;stroke:none"
+       style="opacity:1;fill:#5294e2;fill-opacity:1;stroke:none;stroke-width:1.52752519"
        id="rect4270-9"
-       width="24"
-       height="2"
-       x="2"
+       width="28"
+       height="4"
+       x="0"
        y="296" />
   </g>
 </svg>

--- a/common/cinnamon/common-assets/panel/window-list-hover-bottom.svg
+++ b/common/cinnamon/common-assets/panel/window-list-hover-bottom.svg
@@ -8,7 +8,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90.000000"
@@ -17,8 +16,8 @@
    height="4"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="window-list-active-bottom.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="window-list-hover-bottom.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new">
@@ -32,17 +31,17 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="19.769528"
-     inkscape:cx="6.9341604"
-     inkscape:cy="3.0971298"
+     inkscape:cx="-5.5170614"
+     inkscape:cy="6.3329333"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="851"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -85,15 +84,6 @@
          offset="0"
          id="stop4137" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#selected_bg_color"
-       id="linearGradient4139"
-       x1="14"
-       y1="298"
-       x2="14"
-       y2="300"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata4">
@@ -111,7 +101,7 @@
         <dc:source />
         <cc:license
            rdf:resource="" />
-        <dc:title />
+        <dc:title></dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -152,11 +142,11 @@
      id="layer1"
      transform="translate(0,-296)">
     <rect
-       style="opacity:1;fill:url(#linearGradient4139);fill-opacity:1;stroke:none"
+       style="opacity:1;fill:#5294e2;fill-opacity:1;stroke:none;stroke-width:1.08012354"
        id="rect4270-9"
-       width="24"
+       width="28"
        height="2"
-       x="2"
+       x="0"
        y="298" />
   </g>
 </svg>

--- a/common/cinnamon/common-assets/panel/window-list-hover-left.svg
+++ b/common/cinnamon/common-assets/panel/window-list-hover-left.svg
@@ -17,8 +17,8 @@
    height="28"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="window-list-active-left.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="window-list-hover-left.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new">
@@ -31,18 +31,18 @@
      borderopacity="1"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="9.884764"
-     inkscape:cx="6.9544689"
-     inkscape:cy="5.3696817"
+     inkscape:zoom="27.958335"
+     inkscape:cx="-13.236949"
+     inkscape:cy="20.863897"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="851"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -78,6 +78,14 @@
   <defs
      id="defs3">
     <linearGradient
+       id="linearGradient819"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#5294e2;stop-opacity:1;"
+         offset="0"
+         id="stop817" />
+    </linearGradient>
+    <linearGradient
        id="selected_bg_color"
        osb:paint="solid">
       <stop
@@ -87,14 +95,14 @@
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#selected_bg_color"
-       id="linearGradient4139"
-       x1="14"
-       y1="298"
-       x2="14"
-       y2="300"
+       xlink:href="#linearGradient819"
+       id="linearGradient821"
+       x1="274"
+       y1="-1.5"
+       x2="298"
+       y2="-1.5"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(272,-300)" />
+       gradientTransform="matrix(1.1666667,0,0,0.66666667,-47.666667,0)" />
   </defs>
   <metadata
      id="metadata4">
@@ -153,12 +161,12 @@
      id="layer1"
      transform="translate(0,-272)">
     <rect
-       style="opacity:1;fill:url(#linearGradient4139);fill-opacity:1;stroke:none"
+       style="opacity:1;fill:url(#linearGradient821);fill-opacity:1;stroke:none;stroke-width:1.08012342"
        id="rect4270-9"
-       width="24"
+       width="28"
        height="2"
-       x="274"
+       x="272"
        y="-2"
-       transform="matrix(0,1,-1,0,0,0)" />
+       transform="rotate(90)" />
   </g>
 </svg>

--- a/common/cinnamon/common-assets/panel/window-list-hover-right.svg
+++ b/common/cinnamon/common-assets/panel/window-list-hover-right.svg
@@ -8,7 +8,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90.000000"
@@ -17,8 +16,8 @@
    height="28"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="window-list-active-right.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="window-list-hover-right.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new">
@@ -31,18 +30,18 @@
      borderopacity="1"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="9.884764"
-     inkscape:cx="6.9544689"
-     inkscape:cy="5.3696817"
+     inkscape:zoom="19.769528"
+     inkscape:cx="-14.348567"
+     inkscape:cy="15.482706"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="851"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -85,16 +84,6 @@
          offset="0"
          id="stop4137" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#selected_bg_color"
-       id="linearGradient4139"
-       x1="14"
-       y1="298"
-       x2="14"
-       y2="300"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(272,-302)" />
   </defs>
   <metadata
      id="metadata4">
@@ -153,12 +142,12 @@
      id="layer1"
      transform="translate(0,-272)">
     <rect
-       style="opacity:1;fill:url(#linearGradient4139);fill-opacity:1;stroke:none"
+       style="opacity:1;fill:#5294e2;fill-opacity:1;stroke:none;stroke-width:1.08012354"
        id="rect4270-9"
-       width="24"
+       width="28"
        height="2"
-       x="274"
+       x="272"
        y="-4"
-       transform="matrix(0,1,-1,0,0,0)" />
+       transform="rotate(90)" />
   </g>
 </svg>

--- a/common/cinnamon/common-assets/panel/window-list-hover-top.svg
+++ b/common/cinnamon/common-assets/panel/window-list-hover-top.svg
@@ -8,7 +8,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90.000000"
@@ -17,8 +16,8 @@
    height="4"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="window-list-active-top.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="window-list-hover-top.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new">
@@ -31,18 +30,18 @@
      borderopacity="1"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="19.769528"
-     inkscape:cx="-2.1454696"
-     inkscape:cy="3.0971298"
+     inkscape:zoom="39.539056"
+     inkscape:cx="17.468376"
+     inkscape:cy="3.287591"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="851"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -85,15 +84,6 @@
          offset="0"
          id="stop4137" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#selected_bg_color"
-       id="linearGradient4139"
-       x1="14"
-       y1="296"
-       x2="14"
-       y2="298"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata4">
@@ -111,7 +101,7 @@
         <dc:source />
         <cc:license
            rdf:resource="" />
-        <dc:title />
+        <dc:title></dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -152,11 +142,11 @@
      id="layer1"
      transform="translate(0,-296)">
     <rect
-       style="opacity:1;fill:url(#linearGradient4139);fill-opacity:1;stroke:none"
+       style="opacity:1;fill:#5294e2;fill-opacity:1;stroke:none;stroke-width:1.08012342"
        id="rect4270-9"
-       width="24"
+       width="28"
        height="2"
-       x="2"
+       x="0"
        y="296" />
   </g>
 </svg>


### PR DESCRIPTION
Greetings.  I am using Arc-Theme with Cinnamon and have a suggestion regarding coloring for the panel window list icons.  Currently Cinnamon (4.x) with the global-window-lists applet looks something like this:

![current](https://user-images.githubusercontent.com/2560632/53497688-c4fe4300-3ab5-11e9-95b7-164d46167142.png)

I suggest that this is "too much white" under all the running-but-inactive icons and doesn't match the main Arc theme.  I experimented with possibly having all the inactive ones arc-blue, with the active one being arc-orange, but didn't like that appearance.  I also tried to have the active one white, with the inactive ones blue, but this seems a bit opposite to Arc design.

So my current proposal is to have the inactive icons blue (2 px high as previous) with the active icon be blue (4 px high).  By being taller, the Arc theme then takes the color swatch and effectively colors the entire active icon panel background blue.  Here is an example:

![proposed](https://user-images.githubusercontent.com/2560632/53497883-405ff480-3ab6-11e9-8317-bf6129ca00bf.png)

This design idea actually is consistent with other panel items when clicked, such as "show desktop":

![proposed-show-desktop](https://user-images.githubusercontent.com/2560632/53497925-5372c480-3ab6-11e9-8367-1daa8cac587f.png)

...and also when clicking "Main Menu":

![proposed-main-menu](https://user-images.githubusercontent.com/2560632/53497951-5e2d5980-3ab6-11e9-88d7-844ba530fa6b.png)

So I hope you will consider this request or some other approach to reduce the amount of "white" for the inactive icons which actually stands out more than the active blue one presently, leading to a bit of user disorientation.

Also I widened the color bar to the full icon width so that when it is hilighted (active) it doesn't look like it is "clipped" by the app icon.


