### PR TITLE
Fix Gnome shell calendar with 10pt font

### DIFF
--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -1283,10 +1283,10 @@ StScrollBar {
 .calendar-week-number {
   @include fontsize($font-size * 0.75);
   font-weight: bold;
-  width: 2.3em; height: 1.8em;
+  width: 2.0em; height: 1.5em;
   border-radius: 2px;
-  padding: 0.5em 0 0;
-  margin: 6px;
+  padding: 0.4em 0 0;
+  margin: 2px 6px;
   background-color: transparentize($fg_color,0.7);
   color: $bg_color;
 }


### PR DESCRIPTION
Fixes #197 :

![calendar](https://user-images.githubusercontent.com/18715287/55066494-3366fe80-507e-11e9-94dd-c0a5c5376764.png)