### PR TITLE
Fix close buttons in GNOME overview

### DIFF
--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -1445,27 +1445,31 @@ StScrollBar {
 //
 .window-close {
   background-image: url("common-assets/misc/close.svg");
-  background-size: 26px;
-  height: 26px;
-  width: 26px;
+  background-size: 30px;
+  height: 30px;
+  width: 30px;
+  border: 0px;
+  box-shadow: none;
+  background-color: transparent;
+  color: transparent;
 
   &:hover {
     background-image: url("common-assets/misc/close-hover.svg");
-    background-size: 26px;
-    height: 26px;
-    width: 26px;
+    background-size: 30px;
+    height: 30px;
+    width: 30px;
   }
 
   &:active {
     background-image: url("common-assets/misc/close-active.svg");
-    background-size: 26px;
-    height: 26px;
-    width: 26px;
+    background-size: 30px;
+    height: 30px;
+    width: 30px;
   }
 }
 
 .window-close {
-  -shell-close-overlap: 11px;
+  -shell-close-overlap: 14px;
 }
 
 //

--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -1445,9 +1445,9 @@ StScrollBar {
 //
 .window-close {
   background-image: url("common-assets/misc/close.svg");
-  background-size: 30px;
-  height: 30px;
-  width: 30px;
+  background-size: 26px;
+  height: 26px;
+  width: 26px;
   border: 0px;
   box-shadow: none;
   background-color: transparent;
@@ -1455,21 +1455,15 @@ StScrollBar {
 
   &:hover {
     background-image: url("common-assets/misc/close-hover.svg");
-    background-size: 30px;
-    height: 30px;
-    width: 30px;
   }
 
   &:active {
     background-image: url("common-assets/misc/close-active.svg");
-    background-size: 30px;
-    height: 30px;
-    width: 30px;
   }
 }
 
 .window-close {
-  -shell-close-overlap: 14px;
+  -shell-close-overlap: 12px;
 }
 
 //


### PR DESCRIPTION
Fixes the ugly close buttons in the GNOME overview introduced with the GNOME 3.32 update.

Before:
![before](https://user-images.githubusercontent.com/18715287/54913586-5c0ebd00-4ef3-11e9-87d5-ebb0ea296a9d.png)

After:
![after](https://user-images.githubusercontent.com/18715287/54913602-6466f800-4ef3-11e9-9386-ddd62d40b35c.png)

