### PR TITLE
Correct GTK2 dark assets.svg #3e4351 -> #3e4350

### DIFF
--- a/common/gtk-2.0/dark/assets.svg
+++ b/common/gtk-2.0/dark/assets.svg
@@ -990,7 +990,7 @@
          height="21.999998"
          width="22"
          id="rect7903-6"
-         style="opacity:1;fill:#3e4351;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0" />
+         style="opacity:1;fill:#3e4350;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0" />
       <rect
          ry="2"
          rx="2"


### PR DESCRIPTION
#button-insensitive is using `#3e4351` where the correct colour seems to be `#3e4350`