### PR TITLE
Fix gnome shell overview page indicator

### DIFF
--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -1893,13 +1893,20 @@ StScrollBar {
   .page-indicator-icon {
     width: 18px;
     height: 18px;
+    border: none;
+    background-color: transparent;
     background-image: url(common-assets/misc/page-indicator-inactive.svg);
   }
 
   &:hover .page-indicator-icon { background-image: url(common-assets/misc/page-indicator-hover.svg); }
-  &:active .page-indicator-icon { background-image: url(common-assets/misc/page-indicator-active.svg); }
+  &:active .page-indicator-icon {
+    margin: 0;
+    background-color: transparent;
+    background-image: url(common-assets/misc/page-indicator-active.svg); }
   &:checked .page-indicator-icon,
-  &:checked:active { background-image: url(common-assets/misc/page-indicator-checked.svg); }
+  &:checked:active {
+    background-color: transparent;
+    background-image: url(common-assets/misc/page-indicator-checked.svg); }
 }
 
 .no-frequent-applications-label { @extend %status_text; }


### PR DESCRIPTION
Just realized that the GNOME 3.32 update also messed up the page indicators in the gnome shell applications overview.
This PR goes back to the original Arc appearance for the page indicators:

Gnome 3.32             |  Fixed
----------------------|-------------------------
![wrong](https://user-images.githubusercontent.com/18715287/57779039-a52a0300-7725-11e9-96ef-ce1e075f51c6.png)  |  ![right](https://user-images.githubusercontent.com/18715287/57779157-db678280-7725-11e9-87dd-dacac0ecca95.png)