### PR TITLE
Fix gnome shell panel menu corner radius

### DIFF
--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -620,6 +620,7 @@ StScrollBar {
   min-width: 15em;
   color: $fg_color;
   background-color: $panelmenu_bg_color;
+  border-radius: 3px;
 
   .popup-menu-arrow { } //defined globally in the TOP BAR
   .popup-sub-menu {


### PR DESCRIPTION
Follow up to #240, fixes a small visual glitch where the corners of panel button dropdown menus were not properly rounded