### PR TITLE
Fix GNOME settings CSD separator

### DIFF
--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -2623,20 +2623,20 @@ filechooserbutton:drop(active) {
 //
 .sidebar {
   border-style: none;
-  background-color: lighten($bg_color, 2%);
+  background-color: if($variant =='light', transparentize(darken($borders_color, 40%), 82%), $borders_color);
 
   @at-root %sidebar_left,
   &:dir(ltr),
   &.left,
   &.left:dir(rtl) {
-    border-right: 1px solid $borders_color;
+    border-right-style: none;
     border-left-style: none;
   }
 
   @at-root %sidebar_right,
   &:dir(rtl),
   &.right {
-    border-left: 1px solid $borders_color;
+    border-left-style: none;
     border-right-style: none;
   }
 


### PR DESCRIPTION
Fixes #238:

![settingscsd](https://user-images.githubusercontent.com/18715287/57968242-0e995400-7968-11e9-81b7-e3faf698ba68.png)

My first foray into gtk theme ...

Just realized another pull request was posted, closing this