### PR TITLE
Round user icons in GNOME dialogs

### DIFF
--- a/common/gnome-shell/3.30/sass/_common.scss
+++ b/common/gnome-shell/3.30/sass/_common.scss
@@ -315,7 +315,7 @@ StScrollBar {
 
   &-logout-icon {
     border: 0px solid transparent;
-    border-radius: 2px;
+    border-radius: 99px;
     width: 48px;
     height: 48px;
     background-size: contain;
@@ -507,8 +507,8 @@ StScrollBar {
     color: $warning_color;
   }
 
-  &-user-icon {
-    border-radius: 2px;
+  &-icon {
+    border-radius: 99px;
     background-size: contain;
     width: 48px;
     height: 48px;


### PR DESCRIPTION
Make the user pic round in logout (end session) and polkit dialogs, in keeping with GNOME 3.32 styling