### PR TITLE
GSD and headerbar transparency

### DIFF
--- a/common/gtk-3.0/3.18/sass/_common.scss
+++ b/common/gtk-3.0/3.18/sass/_common.scss
@@ -1091,6 +1091,11 @@ GtkComboBox {
   @extend %header_widgets;
 }
 
+.csd headerbar headerbar,
+.csd headerbar headerbar:backdrop {
+  background-color: transparent;
+}
+
 %header_separator {
   -GtkWidget-wide-separators: true;
   -GtkWidget-separator-width: 1px;

--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -1115,6 +1115,11 @@ headerbar {
   @extend %titlebar;
 }
 
+.csd headerbar headerbar,
+.csd headerbar headerbar:backdrop {
+  background-color: transparent;
+}
+
 %header_separator {
   min-width: 1px;
   min-height: 1px;

--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -1115,6 +1115,16 @@ headerbar {
   @extend %titlebar;
 }
 
+.titlebar separator.sidebar {
+  background-color: transparent;
+  border: 0 solid $header_border;
+  box-shadow: inset 0 1px lighten($header_bg, 3%);
+  margin: 0;
+
+  &:dir(ltr) { border-width: 0 1px 1px 0; }
+  &:dir(rtl) { border-width: 0 0 1px 1px; }
+}
+
 .csd headerbar headerbar,
 .csd headerbar headerbar:backdrop {
   background-color: transparent;


### PR DESCRIPTION
cherry-pick from https://github.com/jnsh/arc-theme - primarily to resolve #238 
Note https://github.com/jnsh/arc-theme/commit/b4922180f3335cb17493ffb21a2fdf40e0f2ad33 needed to be cherry-picked to allow the CSD commit to be also cherry-picked