### PR TITLE
Don't hardcode LightDM's combo box font size

### DIFF
--- a/common/gtk-3.0/3.18/sass/_lightdm.scss
+++ b/common/gtk-3.0/3.18/sass/_lightdm.scss
@@ -75,7 +75,6 @@
 
 #login_window #user_combobox {
   color: $fg_color;
-  font: 13px;
 
   .menu { font: normal; }
   .arrow {}

--- a/common/gtk-3.0/3.20/sass/_lightdm.scss
+++ b/common/gtk-3.0/3.20/sass/_lightdm.scss
@@ -75,7 +75,6 @@
 
 #login_window #user_combobox {
   color: $fg_color;
-  font-size: 13px;
 
   menu { font-weight: normal; }
 }


### PR DESCRIPTION
A LightDM style was introduced in https://github.com/NicoHood/arc-theme/commit/943d2bf4594659acc9240d81c7d61d895daa1a18 with hardcoded 13px size for combo box text which makes the font size setting ineffective, but it's still effective for other widgets such as password input or login button. I think this behavior is inconsistent and inflexible. Please, consider removing the hardcoded font style.