### PR TITLE
Fix gnome header bar buttons wiggling around

### DIFF
--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -651,8 +651,6 @@ toolbar.inline-toolbar toolbutton {
 // special case, because path-bars are bugged
 @mixin pathbar_linking_rules($sep_color:if($variant=='light', transparentize($button_border, 0.6), transparentize($button_border, 0.5))) {
 
-  > button + button { border-left-style: none; }
-
   > button:hover:not(:checked):not(:active):not(:only-child) {
 
     &:hover {


### PR DESCRIPTION
The header bar buttons on gnome applications wiggle around when hovering.
[Screen recording](https://files.sibrenvasse.nl/uEMZ1AEjKhkpYSQxj6i1/old.mp4)

After this PR:
[Screen recording](https://files.sibrenvasse.nl/uEMZ1AEjKhkpYSQxj6i1/new.mp4)

Not 100% sure this is the right fix, but I thought I would open a pull request anyway.