### PR TITLE
disable transparency for gnome-shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@ missing
 .idea/
 common/cinnamon/cinnamon-dark.css
 common/cinnamon/cinnamon.css
+common/gnome-shell/**/gnome-shell-solid-dark.css
 common/gnome-shell/**/gnome-shell-dark.css
+common/gnome-shell/**/gnome-shell-solid.css
 common/gnome-shell/**/gnome-shell.css
 common/gtk-3.0/**/*.css
 common/gtk-3.0/**/light/

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -62,33 +62,48 @@ if ENABLE_DARK
 		$(ithemedarkdir)/cinnamon/cinnamon.css
 endif # ENABLE_DARK
 
-endif # ENABLE_GNOME_SHELL
-
+endif # ENABLE_CINNAMON
 
 if ENABLE_GNOME_SHELL
+
 	$(MKDIR_P) $(ithemedir)/gnome-shell
 
+if ENABLE_TRANSPARENCY
 	$(SASSC) $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION)/sass/gnome-shell.scss $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION)/gnome-shell.css;
+	cd $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION) && cp -R \
+		gnome-shell.css \
+		$(ithemedir)/gnome-shell/gnome-shell.css
+else
+	$(SASSC) $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION)/sass/gnome-shell-solid.scss $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION)/gnome-shell-solid.css;
+	cd $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION) && cp -R \
+		gnome-shell-solid.css \
+		$(ithemedir)/gnome-shell/gnome-shell.css
+endif # ENABLE_TRANSPARENCY
 
 	cd $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION) && cp -RL \
 		common-assets \
 		light-assets \
-		gnome-shell.css \
 		$(ithemedir)/gnome-shell
 
 if ENABLE_DARK
 	$(MKDIR_P) $(ithemedarkdir)/gnome-shell
 
+if ENABLE_TRANSPARENCY
 	$(SASSC) $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION)/sass/gnome-shell-dark.scss $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION)/gnome-shell-dark.css;
+	cd $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION) && cp -R \
+		gnome-shell-dark.css \
+		$(ithemedarkdir)/gnome-shell/gnome-shell.css
+else
+	$(SASSC) $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION)/sass/gnome-shell-solid-dark.scss $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION)/gnome-shell-solid-dark.css;
+	cd $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION) && cp -R \
+		gnome-shell-solid-dark.css \
+		$(ithemedarkdir)/gnome-shell/gnome-shell.css
+endif # ENABLE_TRANSPARENCY
 
 	cd $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION) && cp -RL \
 		common-assets \
 		dark-assets \
 		$(ithemedarkdir)/gnome-shell
-
-	cd $(srcdir)/gnome-shell/$(GNOME_SHELL_VERSION) && cp -R \
-		gnome-shell-dark.css \
-		$(ithemedarkdir)/gnome-shell/gnome-shell.css
 endif # ENABLE_DARK
 
 endif # ENABLE_GNOME_SHELL

--- a/common/gnome-shell/3.18/sass/gnome-shell-solid-dark.scss
+++ b/common/gnome-shell/3.18/sass/gnome-shell-solid-dark.scss
@@ -1,0 +1,7 @@
+$variant: 'dark';
+$transparency: 'false';
+$darker: 'false';
+
+@import "_colors"; //use gtk colors
+@import "_drawing";
+@import "_common";

--- a/common/gnome-shell/3.18/sass/gnome-shell-solid.scss
+++ b/common/gnome-shell/3.18/sass/gnome-shell-solid.scss
@@ -1,0 +1,7 @@
+$variant: 'light';
+$transparency: 'false';
+$darker: 'false';
+
+@import "_colors"; //use gtk colors
+@import "_drawing";
+@import "_common";

--- a/common/gnome-shell/3.26/sass/gnome-shell-solid-dark.scss
+++ b/common/gnome-shell/3.26/sass/gnome-shell-solid-dark.scss
@@ -1,0 +1,7 @@
+$variant: 'dark';
+$transparency: 'false';
+$darker: 'false';
+
+@import "_colors"; //use gtk colors
+@import "_drawing";
+@import "_common";

--- a/common/gnome-shell/3.26/sass/gnome-shell-solid.scss
+++ b/common/gnome-shell/3.26/sass/gnome-shell-solid.scss
@@ -1,0 +1,7 @@
+$variant: 'light';
+$transparency: 'false';
+$darker: 'false';
+
+@import "_colors"; //use gtk colors
+@import "_drawing";
+@import "_common";

--- a/common/gnome-shell/3.30/sass/gnome-shell-solid-dark.scss
+++ b/common/gnome-shell/3.30/sass/gnome-shell-solid-dark.scss
@@ -1,0 +1,7 @@
+$variant: 'dark';
+$transparency: 'false';
+$darker: 'false';
+
+@import "_colors"; //use gtk colors
+@import "_drawing";
+@import "_common";

--- a/common/gnome-shell/3.30/sass/gnome-shell-solid.scss
+++ b/common/gnome-shell/3.30/sass/gnome-shell-solid.scss
@@ -1,0 +1,7 @@
+$variant: 'light';
+$transparency: 'false';
+$darker: 'false';
+
+@import "_colors"; //use gtk colors
+@import "_drawing";
+@import "_common";

--- a/common/gnome-shell/3.32/sass/gnome-shell-solid-dark.scss
+++ b/common/gnome-shell/3.32/sass/gnome-shell-solid-dark.scss
@@ -1,0 +1,7 @@
+$variant: 'dark';
+$transparency: 'false';
+$darker: 'false';
+
+@import "_colors"; //use gtk colors
+@import "_drawing";
+@import "_common";

--- a/common/gnome-shell/3.32/sass/gnome-shell-solid.scss
+++ b/common/gnome-shell/3.32/sass/gnome-shell-solid.scss
@@ -1,0 +1,7 @@
+$variant: 'light';
+$transparency: 'false';
+$darker: 'false';
+
+@import "_colors"; //use gtk colors
+@import "_drawing";
+@import "_common";


### PR DESCRIPTION
gnome-shell had a $transparency variable but didn't use before, I think it should obey --disable-transparency argument to build a solid theme.